### PR TITLE
Added basic typescript module declaration and typings folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "url": "https://github.com/DCzajkowski/vue-emoji-picker/issues"
   },
   "homepage": "https://github.com/DCzajkowski/vue-emoji-picker#readme",
+  "typings": "src/@types",
   "devDependencies": {
     "babel-cli": "^6.24.1",
     "babel-core": "^6.0.0",

--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'vue-emoji-picker';


### PR DESCRIPTION
This simply makes the typescript compiler not throw an error that the module has no typing. Props/Methods can be added to the typings later.

I tested this with a forked npm package in Visual Studio Code. Works.