### PR TITLE
Lowercase the searchterm so that it matches

### DIFF
--- a/src/EmojiPicker.vue
+++ b/src/EmojiPicker.vue
@@ -69,7 +69,7 @@
             obj[category] = {}
 
             for (const emoji in this.emojiTable[category]) {
-              if (new RegExp(`.*${escapeRegExp(this.search)}.*`).test(emoji)) {
+              if (new RegExp(`.*${escapeRegExp(this.search.toLowerCase())}.*`).test(emoji)) {
                 obj[category][emoji] = this.emojiTable[category][emoji]
               }
             }


### PR DESCRIPTION
I noticed that the search term must be the correct casing in order search to work. This should remove that requirement.